### PR TITLE
successful updateInvestigationLabel returns HTTP 200

### DIFF
--- a/lib/Core/SignifydAPI.php
+++ b/lib/Core/SignifydAPI.php
@@ -120,7 +120,7 @@ class SignifydAPI
         $error = curl_error($curl);
         curl_close($curl);
 
-        if($info['http_code'] != 201)
+        if($info['http_code'] != 200)
         {
             $this->logError("Returned http error: ".$info['http_code']." Returned http content: ".$response);
             return false;


### PR DESCRIPTION
A successful call to updateInvestigationLabel returns an HTTP code of 200, instead of HTTP/201
