### PR TITLE
Change type from metapackage to library

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
   "name": "signifyd/signifyd-php",
   "description": "Signifyd client API plugin for PHP",
-  "type": "metapackage",
+  "type": "library",
   "license": [
     "MIT"
   ],


### PR DESCRIPTION
> metapackage: An empty package that contains requirements and will trigger their installation, but contains no files and will not write anything to the filesystem. As such, it does not require a dist or source key to be installable.

Metapackages will not copy over any files but only trigger installation of additional packages.

Fixes #14