### PR TITLE
Added missing $message to GuaranteeReponse

### DIFF
--- a/lib/Core/Response/GuaranteeResponse.php
+++ b/lib/Core/Response/GuaranteeResponse.php
@@ -98,6 +98,8 @@ class GuaranteeResponse extends Response
      */
     public $errorMessage;
 
+    public $message = [];
+
     /**
      * The logging class
      *
@@ -381,6 +383,11 @@ class GuaranteeResponse extends Response
     public function setGuaranteeId($guaranteeId)
     {
         $this->guaranteeId = $guaranteeId;
+    }
+    
+    public function addMessage($message)
+    {
+        $this->message[] = $message;
     }
 
 }


### PR DESCRIPTION
Adding $message variable and addMessage function to GuaranteeResponse class to allow for error messages to be added. The addMessage function is being called from lines 267 and 274 of core/Connection.php when a bad guarantee response is received.