### PR TITLE
MAG-820 Fixed "Creation of dynamic property Signifyd\Core\Response\Sa…

### DIFF
--- a/lib/Core/Response/SaleResponse.php
+++ b/lib/Core/Response/SaleResponse.php
@@ -17,6 +17,7 @@ use Signifyd\Core\Exceptions\LoggerException;
 use Signifyd\Core\Response;
 use Signifyd\Models\Decision;
 use Signifyd\Models\Coverage;
+use Signifyd\Core\Logging;
 
 class SaleResponse extends Response
 {
@@ -60,6 +61,11 @@ class SaleResponse extends Response
     public $errors;
 
     /**
+     * @var Logging
+     */
+    public $logger;
+
+    /**
      * The class attributes
      *
      * @var array $fields The list of class fields
@@ -88,16 +94,10 @@ class SaleResponse extends Response
     ];
 
     /**
-     * UserAccount constructor.
-     *
-     * @param array $data The user account data
+     * @param Logging $logger
      */
-    public function __construct($logger)
+    public function __construct(Logging $logger)
     {
-        if (!is_object($logger) || get_class($logger) !== 'Signifyd\Core\Logging') {
-            throw new LoggerException('Invalid logger parameter');
-        }
-
         $this->logger = $logger;
     }
 


### PR DESCRIPTION
MAG-820 Fixed "Creation of dynamic property Signifyd\Core\Response\SaleResponse::$logger is deprecated" error message on Magento 2.4.6 PHP 8.2